### PR TITLE
feat: label spot instanses

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Well-Known [labels](https://kubernetes.io/docs/reference/labels-annotations-tain
 Talos specific labels:
 * node.cloudprovider.kubernetes.io/clustername - talos cluster name
 * node.cloudprovider.kubernetes.io/platform - name of platform
+* node.cloudprovider.kubernetes.io/lifecycle - spot instance type
 
 Node specs:
 * providerID magic string

--- a/pkg/talos/cloud.go
+++ b/pkg/talos/cloud.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	// ProviderName is the name of the Talo provider.
+	// ProviderName is the name of the Talos provider.
 	ProviderName = "talos"
 	// ServiceAccountName is the service account name used in kube-system namespace.
 	ServiceAccountName = "talos-cloud-controller-manager"
@@ -19,6 +19,8 @@ const (
 	ClusterNameNodeLabel = "node.cloudprovider.kubernetes.io/clustername"
 	// ClusterNodePlatformLabel is the node label of platform name.
 	ClusterNodePlatformLabel = "node.cloudprovider.kubernetes.io/platform"
+	// ClusterNodeLifeCycleLabel is a life cycle type of compute node.
+	ClusterNodeLifeCycleLabel = "node.cloudprovider.kubernetes.io/lifecycle"
 )
 
 type cloud struct {


### PR DESCRIPTION
Set label `node.cloudprovider.kubernetes.io/lifecycle=spot` to spot instance.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
