### PR TITLE
fix: csr keyusage check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY go.mod go.sum /src
 RUN go mod download && go mod verify
 
 COPY . .
-ARG TAG
+ARG VERSION
 RUN make build-all-archs
 
 ########################################

--- a/hack/talos-config.yaml
+++ b/hack/talos-config.yaml
@@ -1,5 +1,6 @@
 global:
   approveNodeCSR: true
+  skipForeignNode: false
   # endpoints:
   #   - 1.2.3.4
   #   - 4.3.2.1

--- a/pkg/certificatesigningrequest/controller.go
+++ b/pkg/certificatesigningrequest/controller.go
@@ -93,13 +93,12 @@ func (r *Reconciler) Run(ctx context.Context) {
 					continue
 				}
 
-				_, err = r.kclient.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csr.Name, csr, metav1.UpdateOptions{})
-				if err != nil {
+				if _, err := r.kclient.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csr.Name, csr, metav1.UpdateOptions{}); err != nil {
 					klog.Errorf("CertificateSigningRequestReconciler: failed to approve/deny CSR %s: %v", csr.Name, err)
 				}
 
 				if !valid {
-					klog.V(3).Infof("CertificateSigningRequestReconciler: has been denied: %s, %+v", csr.Name, err.Error())
+					klog.Warningf("CertificateSigningRequestReconciler: has been denied: %s", csr.Name)
 				} else {
 					klog.V(3).Infof("CertificateSigningRequestReconciler: has been approved: %s", csr.Name)
 				}

--- a/pkg/certificatesigningrequest/utils_test.go
+++ b/pkg/certificatesigningrequest/utils_test.go
@@ -239,6 +239,22 @@ func TestValidateKubeletServingCSRInvalid(t *testing.T) {
 			},
 			expectedError: errKeyUsageMismatch,
 		},
+		{
+			msg: "Invalid key usages, ServerAuth missing",
+			x509cr: x509.CertificateRequest{
+				Subject: pkix.Name{
+					CommonName:   cname,
+					Organization: []string{org},
+				},
+				DNSNames:    dnsNames,
+				IPAddresses: ipAddresses,
+			},
+			keyUsages: []certificatesv1.KeyUsage{
+				certificatesv1.UsageDigitalSignature,
+				certificatesv1.UsageDigitalSignature,
+			},
+			expectedError: errKeyUsageMismatch,
+		},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/talos/cloud.go
+++ b/pkg/talos/cloud.go
@@ -90,6 +90,8 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	}(c)
 
 	if c.cfg.Global.ApproveNodeCSR {
+		klog.Infof("Started CSR Node controller")
+
 		c.csrController = certificatesigningrequest.NewCsrController(c.client.kclient, csrNodeChecks)
 		go c.csrController.Run(c.ctx)
 	}


### PR DESCRIPTION
DeepEqual sees different in unsorted slices.
We will check allowed keyUsage options,
and makes chore that it has two important flags.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
