### PR TITLE
fix: azure providerID

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,6 +40,9 @@ jobs:
           version: v1.55.2
           args: --config=.golangci.yml
       - name: Build
-        run: make build
+        timeout-minutes: 10
+        run: make images
+        env:
+          PLATFORM: "linux/amd64"
       - name: Test
         run: make unit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.4
 ########################################
 
-FROM --platform=${BUILDPLATFORM} golang:1.20-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.21-alpine AS builder
 RUN apk update && apk add --no-cache make
 WORKDIR /src
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,11 @@ help: ## This help menu.
 build-all-archs:
 	@for arch in $(ARCHS); do $(MAKE) ARCH=$${arch} build ; done
 
+.PHONY: clean
+clean: ## Clean
+	rm -rf dist/
+	rm -f talos-cloud-controller-manager-*
+
 .PHONY: build
 build: ## Build
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "$(GO_LDFLAGS)" \

--- a/pkg/talos/instances.go
+++ b/pkg/talos/instances.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/siderolabs/talos-cloud-controller-manager/pkg/utils/platform"
+
 	v1 "k8s.io/api/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
@@ -54,6 +56,14 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		providerID := meta.ProviderID
 		if providerID == "" {
 			providerID = fmt.Sprintf("%s://%s/%s", ProviderName, meta.Platform, providedIP)
+		}
+
+		// Fix for Azure, resource group name must be lower case.
+		if meta.Platform == "azure" {
+			providerID, err = platform.AzureConvertResourceGroupNameToLower(providerID)
+			if err != nil {
+				return nil, fmt.Errorf("error converting resource group name to lower case: %w", err)
+			}
 		}
 
 		ifaces, err := i.c.getNodeIfaces(ctx, providedIP)

--- a/pkg/utils/platform/azure.go
+++ b/pkg/utils/platform/azure.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package platform includes platform specific functions.
+package platform
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// https://github.com/kubernetes-sigs/cloud-provider-azure/blob/4192b264611aebef8070505dd56680a862acfbbf/pkg/provider/azure_wrap.go#L37
+var (
+	azureResourceGroupNameRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/(?:.*)`)
+)
+
+// AzureConvertResourceGroupNameToLower converts the resource group name in the resource ID to be lowered.
+// https://github.com/kubernetes-sigs/cloud-provider-azure/blob/4192b264611aebef8070505dd56680a862acfbbf/pkg/provider/azure_wrap.go#L91
+func AzureConvertResourceGroupNameToLower(resourceID string) (string, error) {
+	matches := azureResourceGroupNameRE.FindStringSubmatch(resourceID)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("%q isn't in Azure resource ID format %q", resourceID, azureResourceGroupNameRE.String())
+	}
+
+	resourceGroup := matches[1]
+
+	return strings.Replace(resourceID, resourceGroup, strings.ToLower(resourceGroup), 1), nil
+}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Set resourceGroup name to low case.
Azure-node-autoscaller works unstable if resourceGroup has upper case symbols.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
