### PR TITLE
feat: support CloudDualStackNodeIPs

### DIFF
--- a/pkg/utils/net/net.go
+++ b/pkg/utils/net/net.go
@@ -38,3 +38,44 @@ func SortedNodeIPs(nodeIP string, first, second []string) (res []string) {
 
 	return res
 }
+
+// PreferedDualStackNodeIPs returns the first IPv4 and IPv6 addresses from the list of IPs.
+func PreferedDualStackNodeIPs(preferIPv6 bool, ips []string) []string {
+	var ipv6, ipv4 string
+
+	for _, ip := range ips {
+		if nip, err := netip.ParseAddr(ip); err == nil {
+			if nip.Is6() {
+				if ipv6 == "" {
+					ipv6 = nip.String()
+				}
+			} else {
+				if ipv4 == "" {
+					ipv4 = nip.String()
+				}
+			}
+		}
+	}
+
+	res := []string{}
+
+	if preferIPv6 {
+		if ipv6 != "" {
+			res = append(res, ipv6)
+		}
+
+		if ipv4 != "" {
+			res = append(res, ipv4)
+		}
+	} else {
+		if ipv4 != "" {
+			res = append(res, ipv4)
+		}
+
+		if ipv6 != "" {
+			res = append(res, ipv6)
+		}
+	}
+
+	return res
+}

--- a/pkg/utils/net/net_test.go
+++ b/pkg/utils/net/net_test.go
@@ -106,3 +106,49 @@ func TestSortedNodeIPs(t *testing.T) {
 		})
 	}
 }
+
+func TestPreferedDualStackNodeIPs(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct { //nolint:govet
+		name       string
+		preferIPv6 bool
+		nodeIPs    []string
+		expected   []string
+	}{
+		{
+			name:       "one nodeIP",
+			preferIPv6: false,
+			nodeIPs:    []string{"192.168.0.1"},
+			expected:   []string{"192.168.0.1"},
+		},
+		{
+			name:       "dualstack nodeIP",
+			preferIPv6: false,
+			nodeIPs:    []string{"192.168.0.1", "fd00::1"},
+			expected:   []string{"192.168.0.1", "fd00::1"},
+		},
+		{
+			name:       "dualstack nodeIP preferIPv6",
+			preferIPv6: true,
+			nodeIPs:    []string{"192.168.0.1", "fd00::1"},
+			expected:   []string{"fd00::1", "192.168.0.1"},
+		},
+		{
+			name:       "dualstack nodeIP preferIPv6 with external IPs",
+			preferIPv6: true,
+			nodeIPs:    []string{"192.168.0.1", "fd00::1", "1.1.1.1", "1111:2222:3333::1", "2000:123:123::9b87:57a7:38bf:6c71"},
+			expected:   []string{"fd00::1", "192.168.0.1"},
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := utilnet.PreferedDualStackNodeIPs(tt.preferIPv6, tt.nodeIPs)
+
+			assert.Equal(t, fmt.Sprintf("%v", tt.expected), fmt.Sprintf("%v", result))
+		})
+	}
+}


### PR DESCRIPTION
Talos CCM now supports the `CloudDualStackNodeIPs` feature gate. This feature allows the user(cloud) to specify a list of IPv4 and IPv6 addresses for each node in the cluster. https://github.com/kubernetes/kubernetes/pull/120275


Closes https://github.com/siderolabs/talos-cloud-controller-manager/issues/101

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
