### PR TITLE
feat: node transformer feature flags

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.57.1
+          version: v1.58.0
           args: --timeout=5m --config=.golangci.yml
       - name: Build
         timeout-minutes: 10

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,16 +143,17 @@ linters:
     - errorlint
     - exhaustruct
     - exhaustivestruct
+    - err113
     - forbidigo
     - forcetypeassert
     - funlen
-    - gas
     - gochecknoglobals
     - gochecknoinits
     - gocognit
     - godox
-    - goerr113
     - gomnd
+    - gosec
+    - mnd
     - ifshort
     - ireturn # we return interfaces
     - maintidx
@@ -175,7 +176,6 @@ linters:
 
     # temporarily disabled linters
     - copyloopvar
-    # https://github.com/golangci/golangci-lint/issues/4606
     - intrange
 
     # abandoned linters for which golangci shows the warning that the repo is archived by the owner
@@ -188,6 +188,7 @@ linters:
     - deadcode
     - ifshort
     - perfsprint
+    - execinquery
 
   disable-all: false
   fast: false

--- a/pkg/talos/instances.go
+++ b/pkg/talos/instances.go
@@ -104,7 +104,7 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 			return nil, fmt.Errorf("error getting interfaces list from the node %s: %w", node.Name, err)
 		}
 
-		addresses := getNodeAddresses(i.c.config, meta.Platform, nodeIPs, ifaces)
+		addresses := getNodeAddresses(i.c.config, meta.Platform, &nodeSpec.Features, nodeIPs, ifaces)
 
 		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: node.Name})
 


### PR DESCRIPTION
Introduce feature flags:
* PublicIPDiscovery enables the Cloud Controller Manager (CCM) to identify global/public IPs on the node.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
