### PR TITLE
fix: make possible mutate provider-id

### DIFF
--- a/pkg/talos/instances.go
+++ b/pkg/talos/instances.go
@@ -84,14 +84,14 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 
 		klog.V(5).Infof("instances.InstanceMetadata() resource: %+v", meta)
 
-		providerID := meta.ProviderID
-		if providerID == "" {
-			providerID = fmt.Sprintf("%s://%s/%s", ProviderName, meta.Platform, nodeIP)
+		if meta.ProviderID == "" {
+			meta.ProviderID = fmt.Sprintf("%s://%s/%s", ProviderName, meta.Platform, nodeIP)
 		}
 
 		// Fix for Azure, resource group name must be lower case.
+		// Since Talos 1.8 fixed it, we can remove this code in the future.
 		if meta.Platform == "azure" {
-			providerID, err = platform.AzureConvertResourceGroupNameToLower(providerID)
+			meta.ProviderID, err = platform.AzureConvertResourceGroupNameToLower(meta.ProviderID)
 			if err != nil {
 				return nil, fmt.Errorf("error converting resource group name to lower case: %w", err)
 			}
@@ -149,7 +149,7 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		}
 
 		return &cloudprovider.InstanceMetadata{
-			ProviderID:    providerID,
+			ProviderID:    meta.ProviderID,
 			InstanceType:  meta.InstanceType,
 			NodeAddresses: addresses,
 			Zone:          meta.Zone,

--- a/pkg/transformer/transformer_test.go
+++ b/pkg/transformer/transformer_test.go
@@ -117,7 +117,7 @@ func TestMatch(t *testing.T) {
 				{
 					Name: "my-transformer",
 					Labels: map[string]string{
-						"label-template": "my-value-{{ .Spot }}-{{ .Zone }}",
+						"label-template": "my-value-{{ .Spot }}-{{ .Zone }}a",
 					},
 				},
 			},
@@ -128,7 +128,7 @@ func TestMatch(t *testing.T) {
 			expected: &transformer.NodeSpec{
 				Annotations: map[string]string{},
 				Labels: map[string]string{
-					"label-template": "my-value-false-",
+					"label-template": "my-value-false-a",
 				},
 			},
 		},
@@ -232,6 +232,22 @@ func TestMatch(t *testing.T) {
 				Hostname: "test-hostname",
 				Zone:     "us-west1",
 			},
+		},
+		{
+			name: "Transform labels with bad label name",
+			terms: []transformer.NodeTerm{
+				{
+					Name: "my-transformer",
+					Labels: map[string]string{
+						"-template": "my-value",
+					},
+				},
+			},
+			metadata: runtime.PlatformMetadataSpec{
+				Platform: "test-platform",
+				Hostname: "test-hostname",
+			},
+			expectedError: fmt.Errorf("invalid label name \"-template\": [name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]"), //nolint:lll
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
We should allow changing the Provider ID string in CCM. And add label key/value validation.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
