### PR TITLE
chore: clean flag

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -61,10 +61,6 @@ global:
   # Parameter is optional, by default is "false"
   approveNodeCSR: true
 
-  # Skip non-Talos nodes after initialisation
-  # Parameter is optional, by default is "false"
-  skipForeignNode: false
-
   # The list of endpoints to connect to the Talos API (control-plane)
   # Parameter is optional, by default the controller will discover the control-plane endpoint
   endpoints:

--- a/hack/ccm-config.yaml
+++ b/hack/ccm-config.yaml
@@ -1,6 +1,5 @@
 global:
   approveNodeCSR: true
-  skipForeignNode: false
   # endpoints:
   #   - 1.2.3.4
   #   - 4.3.2.1

--- a/pkg/talos/cloud_config.go
+++ b/pkg/talos/cloud_config.go
@@ -26,8 +26,6 @@ type cloudConfigGlobal struct {
 	ClusterName string `yaml:"clusterName,omitempty"`
 	// Talos API endpoints.
 	Endpoints []string `yaml:"endpoints,omitempty"`
-	// Do not update foreign initialized node.
-	SkipForeignNode bool `yaml:"skipForeignNode,omitempty"`
 	// Prefer IPv6.
 	PreferIPv6 bool `yaml:"preferIPv6,omitempty"`
 }

--- a/pkg/talos/instances_test.go
+++ b/pkg/talos/instances_test.go
@@ -41,7 +41,6 @@ func TestInstanceMetadata(t *testing.T) {
 	t.Setenv("TALOSCONFIG", "../../hack/talosconfig")
 
 	cfg := cloudConfig{}
-	cfg.Global.SkipForeignNode = true
 
 	ctx := context.Background()
 	client, err := newClient(ctx, &cfg)


### PR DESCRIPTION
Since the introduction of transformation rules, this logic is no longer necessary. The skipForeignNode flag was undocumented before, making its removal straightforward.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
