### PR TITLE
feat: ipv6 123 subnets

### DIFF
--- a/pkg/nodeipam/ipam/cloud_allocator.go
+++ b/pkg/nodeipam/ipam/cloud_allocator.go
@@ -628,8 +628,10 @@ func (r *cloudAllocator) addCIDRSet(cidr string) error {
 		}
 
 		mask = 80
-	case mask > 120:
+	case mask > 123:
 		return fmt.Errorf("CIDRv6 is too small: %v", subnet.String())
+	case mask > 119:
+		break
 	default:
 		mask += 16
 	}

--- a/pkg/nodeipam/ipam/cloud_allocator_test.go
+++ b/pkg/nodeipam/ipam/cloud_allocator_test.go
@@ -65,10 +65,22 @@ func TestAddCIDRSet(t *testing.T) {
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:0/112"),
 		},
 		{
-			name:                "CIDRv6 with mask size 120",
+			name:                "CIDRv6 with mask size 120, 256 pods",
 			cidr:                "2000::aaaa:bbbb:cccc:123/120",
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:100/120"),
+		},
+		{
+			name:                "CIDRv6 with mask size 122, 64 pods",
+			cidr:                "2000::aaaa:bbbb:cccc:123/122",
+			expectedSize:        1,
+			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:100/122"),
+		},
+		{
+			name:                "CIDRv6 with mask size 123, 32 pods",
+			cidr:                "2000::aaaa:bbbb:cccc:123/123",
+			expectedSize:        1,
+			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:120/123"),
 		},
 		{
 			name:          "CIDRv6 with mask size 124",


### PR DESCRIPTION
Set a limit of 32 pods per node in your Kubernetes cluster. Some cloud providers offer a /123 IPv6 subnet for nodes, which is typically sufficient for most use cases.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
