### PR TITLE
fix: hostname in transformation rules

### DIFF
--- a/pkg/talos/instances.go
+++ b/pkg/talos/instances.go
@@ -139,6 +139,10 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 			}
 		}
 
+		if meta.Hostname == "" {
+			meta.Hostname = node.Name
+		}
+
 		var sysInfo *hardware.SystemInformationSpec
 
 		if len(i.c.config.Transformations) > 0 {


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

The hostname is very important for transformation rules. It should be set if the metaserver returns an empty string.

## Why? (reasoning)

closes https://github.com/siderolabs/talos-cloud-controller-manager/issues/250

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
