### PR TITLE
fix: service account name

### DIFF
--- a/charts/talos-cloud-controller-manager/Chart.yaml
+++ b/charts/talos-cloud-controller-manager/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/talos-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/talos-cloud-controller-manager/templates/deployment.yaml
@@ -61,8 +61,12 @@ spec:
           {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.daemonSet.enabled }}
           env:
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+          {{- if .Values.daemonSet.enabled }}
             - name: TALOS_ENDPOINTS
               valueFrom:
                 fieldRef:

--- a/cmd/talos-cloud-controller-manager/main.go
+++ b/cmd/talos-cloud-controller-manager/main.go
@@ -62,10 +62,15 @@ func main() {
 		Constructor: nodeIpamController.startNodeIpamControllerWrapper,
 	}
 
+	serviceAccountName := os.Getenv(talos.ServiceAccountNameEnv)
+	if serviceAccountName == "" {
+		serviceAccountName = talos.ServiceAccountName
+	}
+
 	nodeCSRApproval := nodeCSRApprovalController{}
 	controllerInitializers[kcmnames.CertificateSigningRequestApprovingController] = app.ControllerInitFuncConstructor{
 		InitContext: app.ControllerInitContext{
-			ClientName: talos.ServiceAccountName,
+			ClientName: serviceAccountName,
 		},
 		Constructor: nodeCSRApproval.startNodeCSRApprovalControllerWrapper,
 	}

--- a/pkg/talos/cloud.go
+++ b/pkg/talos/cloud.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/siderolabs/talos-cloud-controller-manager/pkg/talosclient"
 
@@ -16,8 +17,11 @@ import (
 const (
 	// ProviderName is the name of the Talos provider.
 	ProviderName = "talos"
+
 	// ServiceAccountName is the service account name used in kube-system namespace.
 	ServiceAccountName = "talos-cloud-controller-manager"
+	// ServiceAccountNameEnv is the environment variable for the service account name.
+	ServiceAccountNameEnv = "SERVICE_ACCOUNT"
 
 	// ClusterNameNodeLabel is the node label of cluster-name.
 	ClusterNameNodeLabel = "node.cloudprovider.kubernetes.io/clustername"
@@ -90,7 +94,12 @@ func newClient(ctx context.Context, config *cloudConfig) (*client, error) {
 // to perform housekeeping or run custom controllers specific to the cloud provider.
 // Any tasks started here should be cleaned up when the stop channel closes.
 func (c *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
-	c.client.kclient = clientBuilder.ClientOrDie(ServiceAccountName)
+	serviceAccountName := os.Getenv(ServiceAccountNameEnv)
+	if serviceAccountName == "" {
+		serviceAccountName = ServiceAccountName
+	}
+
+	c.client.kclient = clientBuilder.ClientOrDie(serviceAccountName)
 
 	klog.InfoS("clientset initialized")
 


### PR DESCRIPTION
Redefine the default service account name using environment variables.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

#286

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
