### PR TITLE
fix: move Talos CCM port outside ephemeral range

### DIFF
--- a/charts/talos-cloud-controller-manager/values.yaml
+++ b/charts/talos-cloud-controller-manager/values.yaml
@@ -101,14 +101,14 @@ securityContext:
 
 service:
   # -- Service HTTPS port to expose controller.
-  port: 50258
+  port: 10458
   # -- Container HTTPS port.
-  containerPort: 50258
+  containerPort: 10458
   # -- Additional custom annotations for Service.
   annotations: {}
     # prometheus.io/scrape: "true"
     # prometheus.io/scheme: "https"
-    # prometheus.io/port: "50258"
+    # prometheus.io/port: "10458"
 
 # -- Resource requests and limits.
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,14 +4,14 @@ This document is a reflection of the current state of the exposed metrics of the
 
 ## Gather metrics from talos-cloud-controller-manager
 
-By default, the Talos CCM exposes metrics on the `https://localhost:50258/metrics` endpoint.
+By default, the Talos CCM exposes metrics on the `https://localhost:10458/metrics` endpoint.
 
 Enabling the metrics is done by setting the `--secure-port` and the `--authorization-always-allow-paths` flag to allow access to the `/metrics` endpoint.
 
 ```yaml
 talos-cloud-controller-manager
   --authorization-always-allow-paths="/metrics"
-  --secure-port=50258
+  --secure-port=10458
 ```
 
 ### Helm chart values
@@ -20,11 +20,11 @@ The following values can be set in the Helm chart to expose the metrics of the T
 
 ```yaml
 service:
-  containerPort: 50258
+  containerPort: 10458
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: "https"
-    prometheus.io/port: "50258"
+    prometheus.io/port: "10458"
 ```
 
 ## Metrics exposed by the CCM


### PR DESCRIPTION
# Pull Request

## What? (description)

Change the default Talos Cloud Controller Manager port from `50258` to `10458`.

Fixes #338

## Why? (reasoning)

The previous default port `50258` is inside the default Talos Linux ephemeral port range (`32768-60999`). For host-networked deployments, another process can use that port as an outbound source port before Talos CCM starts, which can make Talos CCM fail to bind its listener.

Port `10458` stays outside the Linux ephemeral port range and the default Kubernetes NodePort range while keeping the Kubernetes CCM-style `58` suffix.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.