### PR TITLE
fix(chart): move ServiceAccount namespace inside metadata block

### DIFF
--- a/charts/talos-cloud-controller-manager/Chart.yaml
+++ b/charts/talos-cloud-controller-manager/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.5
+version: 0.5.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/talos-cloud-controller-manager/templates/serviceaccount.yaml
+++ b/charts/talos-cloud-controller-manager/templates/serviceaccount.yaml
@@ -9,8 +9,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: talos.dev/v1alpha1
 kind: ServiceAccount


### PR DESCRIPTION
# Pull Request

## What? (description)

Move `namespace: {{ .Release.Namespace }}` for the native `v1` ServiceAccount inside the `metadata:` block and inside the `{{- if }}` gate, placing it last.

## Why? (reasoning)

The `namespace` line sat after `{{- end }}`, outside the `if`. With `create=false` it renders as a standalone YAML document with no `kind:`, which Helm emits as a manifest at the end of the output.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you linted your code (`make lint`)
- [x] you linted your code (`make unit`)

> See `make help` for a description of the available targets.