### PR TITLE
fix(chart): allow setting the cloud config global block

### DIFF
--- a/charts/talos-cloud-controller-manager/Chart.yaml
+++ b/charts/talos-cloud-controller-manager/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/talos-cloud-controller-manager/README.md
+++ b/charts/talos-cloud-controller-manager/README.md
@@ -1,6 +1,6 @@
 # talos-cloud-controller-manager
 
-![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.13.0](https://img.shields.io/badge/AppVersion-v1.13.0-informational?style=flat-square)
+![Version: 0.5.7](https://img.shields.io/badge/Version-0.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.13.0](https://img.shields.io/badge/AppVersion-v1.13.0-informational?style=flat-square)
 
 Talos Cloud Controller Manager Helm Chart
 
@@ -77,6 +77,7 @@ helm upgrade -i --namespace=kube-system -f talos-ccm.yaml \
 | enabledControllers | list | `["cloud-node","node-csr-approval"]` | List of controllers should be enabled. Use '*' to enable all controllers. Support only `cloud-node, cloud-node-lifecycle, node-csr-approval, node-ipam-controller` controllers. |
 | extraArgs | list | `[]` | Any extra arguments for talos-cloud-controller-manager |
 | fullnameOverride | string | `""` | String to fully override deployment name. |
+| globalConfig | object | `{}` | Global cloud config options: clusterName, preferIPv6. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy: IfNotPresent or Always. |
 | image.repository | string | `"ghcr.io/siderolabs/talos-cloud-controller-manager"` | CCM image repository. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/talos-cloud-controller-manager/ci/values.yaml
+++ b/charts/talos-cloud-controller-manager/ci/values.yaml
@@ -8,5 +8,8 @@ nodeSelector:
 
 logVerbosityLevel: 4
 
+globalConfig:
+  preferIPv6: true
+
 enabledControllers:
   - cloud-node

--- a/charts/talos-cloud-controller-manager/templates/configmap.yaml
+++ b/charts/talos-cloud-controller-manager/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
 data:
   ccm-config.yaml: |
     global:
+    {{- with .Values.globalConfig }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- with .Values.transformations }}
     transformations:
       {{- toYaml . | nindent 6 }}

--- a/charts/talos-cloud-controller-manager/values.yaml
+++ b/charts/talos-cloud-controller-manager/values.yaml
@@ -41,6 +41,9 @@ enabledControllers:
   - node-csr-approval
   # - node-ipam-controller
 
+# -- Global cloud config options: clusterName, preferIPv6.
+globalConfig: {}
+
 # -- List of node transformations.
 # Available matchExpressions key values: https://github.com/siderolabs/talos/blob/main/pkg/machinery/resources/runtime/platform_metadata.go#L28
 transformations: []


### PR DESCRIPTION
The cloud config supports global.clusterName and global.preferIPv6, but the chart only rendered transformations under global:, so neither could be set through helm values. Setting global.preferIPv6 directly does not work either, as global is Helm's reserved key for subchart values.

## Acceptance

Please use the following checklist:

- N/A you linked an issue (if applicable)
- N/A you included tests (if applicable)
- NO  you ran conformance (`make conformance`) — no Docker locally; CI enforces conformance
- N/A you linted your code (`make lint`)
- N/A you linted your code (`make unit`)
- [X] ran `make helm-unit`
- [X] deployed the chart to a live k8s cluster with CCM pod healthy, preferIPv6 present in the mounted ccm-config.yaml, and preferIPv6 applied

> See `make help` for a description of the available targets.
