### PR TITLE
fix: size ipv6 pod subnets by node max pods

### DIFF
--- a/pkg/nodeipam/ipam/cidrset/cidr_set.go
+++ b/pkg/nodeipam/ipam/cidrset/cidr_set.go
@@ -148,7 +148,7 @@ func (s *CidrSet) indexToCIDRBlock(index int) *net.IPNet {
 }
 
 func (s *CidrSet) String() string {
-	return fmt.Sprintf("CIDRSet{used: %d}", s.allocatedCIDRs)
+	return fmt.Sprintf("CIDRSet{used: %d, max: %d}", s.allocatedCIDRs, s.maxCIDRs)
 }
 
 // AllocateNext allocates the next free CIDR range. This will set the range

--- a/pkg/nodeipam/ipam/cloud_allocator.go
+++ b/pkg/nodeipam/ipam/cloud_allocator.go
@@ -263,7 +263,7 @@ func (r *cloudAllocator) processNextNodeWorkItem(ctx context.Context) bool {
 		logger.Info("Successfully synced", "node", obj)
 
 		for k, cidrSet := range r.cidrSets {
-			logger.V(5).Info("IPAM status", "node", obj, "subnet", k.String(), "size", cidrSet.String())
+			logger.V(5).Info("IPAM status", "subnet", k.String(), "size", cidrSet.String())
 		}
 
 		return nil
@@ -355,6 +355,28 @@ func (r *cloudAllocator) occupyCIDR(cidr *net.IPNet) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// occupyNodeIPs marks the node's own IPv6 addresses as occupied in the
+// matching CIDR set. This ensures a pod subnet that would include one of the
+// node's own addresses is never allocated to that node.
+func (r *cloudAllocator) occupyNodeIPs(addrs []netip.Addr) error {
+	for _, addr := range addrs {
+		if !addr.Is6() || addr.IsPrivate() {
+			continue
+		}
+
+		ip := net.ParseIP(addr.String())
+		if ip == nil {
+			continue
+		}
+
+		if _, err := r.occupyCIDR(&net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // WARNING: If you're adding any return calls or defer any more work from this
@@ -527,6 +549,31 @@ func (r *cloudAllocator) updateCIDRsAllocation(ctx context.Context, nodeName str
 	return err
 }
 
+// defaultNodeMaxPods is the kubelet default value of --max-pods. It is used
+// when the node has not reported its pod capacity yet.
+const defaultNodeMaxPods = 110
+
+// getNodeMaxPods returns the maximum number of pods that can run on the node.
+// It prefers the allocatable pod capacity reported by the kubelet, falls back
+// to the total capacity, and finally to the kubelet default.
+func getNodeMaxPods(node *v1.Node) int {
+	if node != nil {
+		if pods, ok := node.Status.Allocatable[v1.ResourcePods]; ok {
+			if value, isInt := pods.AsInt64(); isInt && value > 0 {
+				return int(value)
+			}
+		}
+
+		if pods, ok := node.Status.Capacity[v1.ResourcePods]; ok {
+			if value, isInt := pods.AsInt64(); isInt && value > 0 {
+				return int(value)
+			}
+		}
+	}
+
+	return defaultNodeMaxPods
+}
+
 // defineNodeGlobalCIDRs returns the global CIDR for the node.
 func (r *cloudAllocator) defineNodeGlobalCIDRs(ctx context.Context, node *v1.Node) (string, error) {
 	if node == nil {
@@ -567,6 +614,7 @@ func (r *cloudAllocator) defineNodeGlobalCIDRs(ctx context.Context, node *v1.Nod
 		}
 	}
 
+	// Get all public IPv6 CIDRs from the linux node.
 	_, cidrs := talosclient.NodeCIDRDiscovery(ipv6, ifaces)
 	logger.V(4).Info("Node has IPv6 CIDRs", "node", klog.KObj(node), "CIDRs", cidrs)
 
@@ -586,10 +634,16 @@ func (r *cloudAllocator) defineNodeGlobalCIDRs(ctx context.Context, node *v1.Nod
 
 			for _, subnet := range subnets {
 				if ip, ok := netip.AddrFromSlice(subnet.IP); ok && k.Contains(ip) {
+					if err := r.occupyNodeIPs(ipv6); err != nil {
+						return "", fmt.Errorf("error to occupy node IPs in CIDRSet %s: %v", k.String(), err)
+					}
+
 					return k.String(), nil
 				}
 			}
 		}
+
+		maxPods := getNodeMaxPods(node)
 
 		for _, cidr := range cidrs {
 			mask := netip.MustParsePrefix(cidr).Bits()
@@ -597,12 +651,16 @@ func (r *cloudAllocator) defineNodeGlobalCIDRs(ctx context.Context, node *v1.Nod
 				continue
 			}
 
-			logger.V(4).Info("Add IPv6 to CIDRSet", "node", klog.KObj(node), "CIDR", cidr)
+			logger.V(4).Info("Add IPv6 to CIDRSet", "node", klog.KObj(node), "CIDR", cidr, "maxPods", maxPods)
 
-			err := r.addCIDRSet(cidr)
+			err := r.addCIDRSet(cidr, maxPods)
 			if err != nil {
 				return "", fmt.Errorf("error to add CIDRv6 to CIDRSet: %v", err)
 			}
+		}
+
+		if err := r.occupyNodeIPs(ipv6); err != nil {
+			return "", fmt.Errorf("error to occupy node IPs in CIDRSet: %v", err)
 		}
 
 		return cidrs[0], nil
@@ -612,7 +670,9 @@ func (r *cloudAllocator) defineNodeGlobalCIDRs(ctx context.Context, node *v1.Nod
 }
 
 // addCIDRSet adds a new CIDRSet-v6 to the allocator's tracked CIDR sets.
-func (r *cloudAllocator) addCIDRSet(cidr string) error {
+// It returns an error if the resulting pod subnet is too small to accommodate
+// maxPods pods on the node.
+func (r *cloudAllocator) addCIDRSet(cidr string, maxPods int) error {
 	subnet, err := netip.ParsePrefix(cidr)
 	if err != nil {
 		return err
@@ -622,21 +682,22 @@ func (r *cloudAllocator) addCIDRSet(cidr string) error {
 
 	switch {
 	case mask < 64:
+		mask = 80
 		subnet, err = subnet.Addr().Prefix(64)
 		if err != nil {
 			return err
 		}
-
-		mask = 80
-	case mask > 123:
+	case mask > 123: // <16 ips
 		return fmt.Errorf("CIDRv6 is too small: %v", subnet.String())
-	case mask > 119:
-		// Use /120 mask or less as is, only one node can be assigned
-		break
-	case mask > 118:
-		// Use /120 mask, only two nodes can be assigned
+	case mask > 117: // <1024 ips
 		mask += 1
-	case mask > 111:
+
+		addresses := (uint64(1) << (128 - mask)) - 2
+		if uint64(maxPods) > addresses {
+			return fmt.Errorf("CIDRv6 %s is too small: pod subnet /%d provides only %d addresses for %d pods", subnet.String(), mask, addresses, maxPods)
+		}
+
+	case mask > 111: // <65k ips
 		mask += 2
 	case mask > 105:
 		mask += 4

--- a/pkg/nodeipam/ipam/cloud_allocator_test.go
+++ b/pkg/nodeipam/ipam/cloud_allocator_test.go
@@ -30,6 +30,7 @@ func TestAddCIDRSet(t *testing.T) {
 	for _, tt := range []struct {
 		name                string
 		cidr                string
+		maxPods             int
 		expectedError       error
 		expectedSize        int
 		expectedClusterCIDR netip.Prefix
@@ -37,78 +38,105 @@ func TestAddCIDRSet(t *testing.T) {
 		{
 			name:                "CIDRv6 with mask size 56",
 			cidr:                "2000::1111:aaaa:bbbb:cccc:123/56",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000:0:0:1111::/64"),
 		},
 		{
 			name:                "CIDRv6 with mask size 64",
 			cidr:                "2000::aaaa:bbbb:cccc:123/64",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::/64"),
 		},
 		{
 			name:                "CIDRv6 with mask size 80",
 			cidr:                "2000::aaaa:bbbb:cccc:123/80",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:0:0:0/80"),
 		},
 		{
 			name:                "CIDRv6 with mask size 96",
 			cidr:                "2000::aaaa:bbbb:cccc:123/96",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:0:0/96"),
 		},
 		{
 			name:                "CIDRv6 with mask size 100",
 			cidr:                "2000::aaaa:bbbb:cccc:123/100",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:c000:0/100"),
 		},
 		{
 			name:                "CIDRv6 with mask size 106",
 			cidr:                "2000::aaaa:bbbb:cccc:123/106",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:ccc0:0/106"),
 		},
 		{
 			name:                "CIDRv6 with mask size 110",
 			cidr:                "2000::aaaa:bbbb:cccc:123/110",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:0/110"),
 		},
 		{
 			name:                "CIDRv6 with mask size 112",
 			cidr:                "2000::aaaa:bbbb:cccc:123/112",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:0/112"),
 		},
 		{
 			name:                "CIDRv6 with mask size 119",
 			cidr:                "2000::aaaa:bbbb:cccc:123/119",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:0/119"),
 		},
 		{
-			name:                "CIDRv6 with mask size 120, 256 pods",
+			name:                "CIDRv6 with mask size 120 (256 addresses), 110 pods",
 			cidr:                "2000::aaaa:bbbb:cccc:123/120",
+			maxPods:             110,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:100/120"),
 		},
 		{
-			name:                "CIDRv6 with mask size 122, 64 pods",
+			name:          "CIDRv6 with mask size 120 (256 addresses), not enough addresses for pods",
+			cidr:          "2000::aaaa:bbbb:cccc:123/120",
+			maxPods:       129,
+			expectedError: fmt.Errorf("CIDRv6 2000::aaaa:bbbb:cccc:123/120 is too small: pod subnet /121 provides only 126 addresses for 129 pods"),
+		},
+		{
+			name:                "CIDRv6 with mask size 122 (64 addresses), 30 pods",
 			cidr:                "2000::aaaa:bbbb:cccc:123/122",
+			maxPods:             30,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:100/122"),
 		},
 		{
-			name:                "CIDRv6 with mask size 123, 32 pods",
+			name:          "CIDRv6 with mask size 122 (64 addresses), not enough addresses for 33 pods",
+			cidr:          "2000::aaaa:bbbb:cccc:123/122",
+			maxPods:       33,
+			expectedSize:  1,
+			expectedError: fmt.Errorf("CIDRv6 2000::aaaa:bbbb:cccc:123/122 is too small: pod subnet /123 provides only 30 addresses for 33 pods"),
+		},
+		{
+			name:                "CIDRv6 with mask size 123 (32 addresses), 10 pods",
 			cidr:                "2000::aaaa:bbbb:cccc:123/123",
+			maxPods:             10,
 			expectedSize:        1,
 			expectedClusterCIDR: netip.MustParsePrefix("2000::aaaa:bbbb:cccc:120/123"),
 		},
 		{
-			name:          "CIDRv6 with mask size 124",
+			name:          "CIDRv6 with mask size 124 (16 addresses)",
 			cidr:          "2000::aaaa:bbbb:cccc:123/124",
+			maxPods:       110,
+			expectedSize:  1,
 			expectedError: fmt.Errorf("CIDRv6 is too small: 2000::aaaa:bbbb:cccc:123/124"),
 		},
 	} {
@@ -117,7 +145,7 @@ func TestAddCIDRSet(t *testing.T) {
 			allocator := cloudAllocator{
 				cidrSets: cidrSets,
 			}
-			err := allocator.addCIDRSet(tt.cidr)
+			err := allocator.addCIDRSet(tt.cidr, tt.maxPods)
 
 			if tt.expectedError != nil {
 				assert.Error(t, err)

--- a/pkg/talosclient/client.go
+++ b/pkg/talosclient/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package talosclient impelent talos client.
+// Package talosclient implements a client for interacting with Talos nodes and retrieving cluster information.
 package talosclient
 
 import (
@@ -208,7 +208,7 @@ func NodeIPDiscovery(nodeIPs []string, ifaces []network.AddressStatusSpec) (publ
 		if iface.LinkName == constants.KubeSpanLinkName ||
 			iface.LinkName == constants.SideroLinkName ||
 			iface.LinkName == "lo" ||
-			iface.LinkName == "cilium_host" ||
+			strings.HasPrefix(iface.LinkName, "cilium") ||
 			strings.HasPrefix(iface.LinkName, "dummy") {
 			continue
 		}
@@ -237,11 +237,13 @@ func NodeIPDiscovery(nodeIPs []string, ifaces []network.AddressStatusSpec) (publ
 
 // NodeCIDRDiscovery returns the public CIDRs of the node with the given filter IPs.
 func NodeCIDRDiscovery(filterIPs []netip.Addr, ifaces []network.AddressStatusSpec) (publicCIDRv4s, publicCIDRv6s []string) {
+	v6Prefixes := []netip.Prefix{}
+
 	for _, iface := range ifaces {
 		if iface.LinkName == constants.KubeSpanLinkName ||
 			iface.LinkName == constants.SideroLinkName ||
 			iface.LinkName == "lo" ||
-			iface.LinkName == "cilium_host" ||
+			strings.HasPrefix(iface.LinkName, "cilium") ||
 			strings.HasPrefix(iface.LinkName, "dummy") {
 			continue
 		}
@@ -249,23 +251,49 @@ func NodeCIDRDiscovery(filterIPs []netip.Addr, ifaces []network.AddressStatusSpe
 		ip := iface.Address.Addr()
 		if ip.IsGlobalUnicast() && !ip.IsPrivate() {
 			if len(filterIPs) == 0 || slices.Contains(filterIPs, ip) {
-				cidr := iface.Address.String()
-
 				if ip.Is6() {
-					if slices.Contains(publicCIDRv6s, cidr) {
+					prefix := iface.Address
+					if !prefix.IsValid() {
 						continue
 					}
 
-					// Prioritize permanent IPv6 addresses
-					if nethelpers.AddressFlag(iface.Flags)&nethelpers.AddressPermanent != 0 {
-						publicCIDRv6s = append([]string{cidr}, publicCIDRv6s...)
-					} else {
-						publicCIDRv6s = append(publicCIDRv6s, cidr)
+					if !slices.ContainsFunc(v6Prefixes, func(p netip.Prefix) bool { return p == prefix }) {
+						v6Prefixes = append(v6Prefixes, prefix)
 					}
 				} else {
-					publicCIDRv4s = append(publicCIDRv4s, cidr)
+					publicCIDRv4s = append(publicCIDRv4s, iface.Address.String())
 				}
 			}
+		}
+	}
+
+	// Sort IPv6 prefixes by mask: lower prefix (larger subnet) has higher priority.
+	slices.SortFunc(v6Prefixes, func(a, b netip.Prefix) int {
+		if a.Bits() != b.Bits() {
+			return a.Bits() - b.Bits()
+		}
+
+		return a.Addr().Compare(b.Addr())
+	})
+
+	// Drop any prefix that is contained within another (forget the smallest subnet).
+	for i, p := range v6Prefixes {
+		contained := false
+
+		for j, q := range v6Prefixes {
+			if i == j {
+				continue
+			}
+
+			if q.Bits() < p.Bits() && q.Contains(p.Addr()) {
+				contained = true
+
+				break
+			}
+		}
+
+		if !contained {
+			publicCIDRv6s = append(publicCIDRv6s, p.String())
 		}
 	}
 

--- a/pkg/talosclient/client_test.go
+++ b/pkg/talosclient/client_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package talosclient_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talos-cloud-controller-manager/pkg/talosclient"
+	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
+	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+)
+
+func TestNodeIPDiscovery(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		nodeIPs       []string
+		ifaces        []network.AddressStatusSpec
+		expectedIPv4s []string
+		expectedIPv6s []string
+	}{
+		{
+			name:    "No interfaces",
+			nodeIPs: []string{},
+			ifaces:  []network.AddressStatusSpec{},
+		},
+		{
+			name:    "Private and link-local addresses are skipped",
+			nodeIPs: []string{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("192.168.0.1/24")},
+				{Address: netip.MustParsePrefix("10.0.0.1/8")},
+				{Address: netip.MustParsePrefix("172.16.0.1/12")},
+				{Address: netip.MustParsePrefix("fe80::e0b5:71ff:fe24:7e60/64")},
+				{Address: netip.MustParsePrefix("fd15:1:2::192:168:0:1/64")},
+			},
+		},
+		{
+			name:    "Public IPv4 addresses",
+			nodeIPs: []string{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("192.168.0.1/24")},
+				{Address: netip.MustParsePrefix("1.2.3.4/24"), LinkName: "external"},
+				{Address: netip.MustParsePrefix("4.3.2.1/24")},
+			},
+			expectedIPv4s: []string{"1.2.3.4", "4.3.2.1"},
+		},
+		{
+			name:    "Public IPv6 addresses",
+			nodeIPs: []string{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("fd15:1:2::192:168:0:1/64")},
+				{Address: netip.MustParsePrefix("2001:1234::1/64")},
+				{Address: netip.MustParsePrefix("2001:1234:4321::32/64")},
+			},
+			expectedIPv6s: []string{"2001:1234::1", "2001:1234:4321::32"},
+		},
+		{
+			name:    "Filtered link names are skipped",
+			nodeIPs: []string{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("1.2.3.4/24"), LinkName: "kubespan"},
+				{Address: netip.MustParsePrefix("4.3.2.1/24"), LinkName: "siderolink"},
+				{Address: netip.MustParsePrefix("5.6.7.8/24"), LinkName: "lo"},
+				{Address: netip.MustParsePrefix("9.8.7.6/24"), LinkName: "cilium_host"},
+				{Address: netip.MustParsePrefix("11.12.13.14/24"), LinkName: "dummy0"},
+				{Address: netip.MustParsePrefix("15.16.17.18/24"), LinkName: "eth0"},
+			},
+			expectedIPv4s: []string{"15.16.17.18"},
+		},
+		{
+			name:    "Node IPs are excluded",
+			nodeIPs: []string{"1.2.3.4", "2001:1234::1"},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("1.2.3.4/24")},
+				{Address: netip.MustParsePrefix("4.3.2.1/24")},
+				{Address: netip.MustParsePrefix("2001:1234::1/64")},
+				{Address: netip.MustParsePrefix("2001:1234:4321::32/64")},
+			},
+			expectedIPv4s: []string{"4.3.2.1"},
+			expectedIPv6s: []string{"2001:1234:4321::32"},
+		},
+		{
+			name:    "Permanent IPv6 addresses have priority",
+			nodeIPs: []string{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("2001:1234:1:2:3:4:5:6/64"), Flags: nethelpers.AddressFlags(nethelpers.AddressManagementTemp)},
+				{Address: netip.MustParsePrefix("2001:1234::1/64"), Flags: nethelpers.AddressFlags(nethelpers.AddressPermanent)},
+			},
+			expectedIPv6s: []string{"2001:1234::1", "2001:1234:1:2:3:4:5:6"},
+		},
+		{
+			name:    "Dualstack with mixed addresses",
+			nodeIPs: []string{"192.168.0.1", "fd15:1:2::192:168:0:1"},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("192.168.0.1/24")},
+				{Address: netip.MustParsePrefix("fe80::e0b5:71ff:fe24:7e60/64")},
+				{Address: netip.MustParsePrefix("fd15:1:2::192:168:0:1/64")},
+				{Address: netip.MustParsePrefix("1.2.3.4/24"), LinkName: "external"},
+				{Address: netip.MustParsePrefix("2001:1234::1/64"), Flags: nethelpers.AddressFlags(nethelpers.AddressPermanent)},
+			},
+			expectedIPv4s: []string{"1.2.3.4"},
+			expectedIPv6s: []string{"2001:1234::1"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4s, ipv6s := talosclient.NodeIPDiscovery(tt.nodeIPs, tt.ifaces)
+
+			assert.Equal(t, tt.expectedIPv4s, ipv4s)
+			assert.Equal(t, tt.expectedIPv6s, ipv6s)
+		})
+	}
+}
+
+func TestNodeCIDRDiscovery(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		filterIPs       []netip.Addr
+		ifaces          []network.AddressStatusSpec
+		expectedCIDRv4s []string
+		expectedCIDRv6s []string
+	}{
+		{
+			name:      "No interfaces",
+			filterIPs: []netip.Addr{},
+			ifaces:    []network.AddressStatusSpec{},
+		},
+		{
+			name:      "Private and link-local addresses are skipped",
+			filterIPs: []netip.Addr{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("192.168.0.1/24")},
+				{Address: netip.MustParsePrefix("10.0.0.1/8")},
+				{Address: netip.MustParsePrefix("fe80::e0b5:71ff:fe24:7e60/64")},
+				{Address: netip.MustParsePrefix("fd15:1:2::192:168:0:1/64")},
+			},
+		},
+		{
+			name:      "Public IPv4 CIDRs",
+			filterIPs: []netip.Addr{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("192.168.0.1/24")},
+				{Address: netip.MustParsePrefix("1.2.3.4/24"), LinkName: "external"},
+				{Address: netip.MustParsePrefix("4.3.2.1/24")},
+			},
+			expectedCIDRv4s: []string{"1.2.3.4/24", "4.3.2.1/24"},
+		},
+		{
+			name:      "Public IPv6 CIDRs",
+			filterIPs: []netip.Addr{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("fd15:1:2::192:168:0:1/64")},
+				{Address: netip.MustParsePrefix("2001:1234::1/64")},
+				{Address: netip.MustParsePrefix("2001:1234:4321::32/64")},
+			},
+			expectedCIDRv6s: []string{"2001:1234::1/64", "2001:1234:4321::32/64"},
+		},
+		{
+			name:      "Filtered link names are skipped",
+			filterIPs: []netip.Addr{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("1.2.3.4/24"), LinkName: "kubespan"},
+				{Address: netip.MustParsePrefix("4.3.2.1/24"), LinkName: "siderolink"},
+				{Address: netip.MustParsePrefix("5.6.7.8/24"), LinkName: "lo"},
+				{Address: netip.MustParsePrefix("9.8.7.6/24"), LinkName: "cilium_host"},
+				{Address: netip.MustParsePrefix("11.12.13.14/24"), LinkName: "dummy0"},
+				{Address: netip.MustParsePrefix("15.16.17.18/24"), LinkName: "eth0"},
+			},
+			expectedCIDRv4s: []string{"15.16.17.18/24"},
+		},
+		{
+			name:      "Filter IPs",
+			filterIPs: []netip.Addr{netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("2001:1234::1")},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("1.2.3.4/24")},
+				{Address: netip.MustParsePrefix("4.3.2.1/24")},
+				{Address: netip.MustParsePrefix("2001:1234::1/64")},
+				{Address: netip.MustParsePrefix("2001:1234:4321::32/64")},
+			},
+			expectedCIDRv4s: []string{"1.2.3.4/24"},
+			expectedCIDRv6s: []string{"2001:1234::1/64"},
+		},
+		{
+			name:      "Nested IPv6 prefixes are deduplicated",
+			filterIPs: []netip.Addr{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("2001:1234:1:2::1/64")},
+				{Address: netip.MustParsePrefix("2001:1234:1:2:3::/80")},
+				{Address: netip.MustParsePrefix("2001:1234:1:2:3:4:5:6/128")},
+			},
+			expectedCIDRv6s: []string{"2001:1234:1:2::1/64"},
+		},
+		{
+			name:      "IPv6 prefixes are sorted by mask",
+			filterIPs: []netip.Addr{},
+			ifaces: []network.AddressStatusSpec{
+				{Address: netip.MustParsePrefix("2001:1234:1:2:3:4:5:6/128")},
+				{Address: netip.MustParsePrefix("2001:1234:4321::32/64")},
+				{Address: netip.MustParsePrefix("2001:1234::1/56")},
+			},
+			expectedCIDRv6s: []string{"2001:1234::1/56", "2001:1234:4321::32/64", "2001:1234:1:2:3:4:5:6/128"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cidrv4s, cidrv6s := talosclient.NodeCIDRDiscovery(tt.filterIPs, tt.ifaces)
+
+			assert.Equal(t, tt.expectedCIDRv4s, cidrv4s)
+			assert.Equal(t, tt.expectedCIDRv6s, cidrv6s)
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos CCM will first have to approve the PR.
-->

## What? (description)

Derive the node's max pods from its allocatable or capacity pod count (kubelet default 110) and fail when the resulting pod subnet is too small to hold that many pods. Also mark the node's own global ipv6 addresses as occupied so they are never allocated to pods.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you linted your code (`make lint`)
- [ ] you linted your code (`make unit`)

> See `make help` for a description of the available targets.
